### PR TITLE
[Bugfix] constrain prevent default to not input fields

### DIFF
--- a/packages/engine/Source/Core/ScreenSpaceEventHandler.js
+++ b/packages/engine/Source/Core/ScreenSpaceEventHandler.js
@@ -32,6 +32,7 @@ function getInputEventKey(type, modifier) {
 }
 
 function getModifier(event, screenSpaceEventHandler) {
+  console.log("getModifier", event, screenSpaceEventHandler._spaceKeyDown);
   if (event.shiftKey) {
     return KeyboardEventModifier.SHIFT;
   } else if (event.ctrlKey) {
@@ -51,11 +52,14 @@ const MouseButton = {
   RIGHT: 2,
 };
 
+
 function handleKeyDown(screenSpaceEventHandler, event) {
   if (event.keyCode === 32) {
     // Space key code
     screenSpaceEventHandler._spaceKeyDown = true;
-    event.preventDefault(); // Prevent page scrolling
+    if (event.target.tagName !== "INPUT" && event.target.tagName !== "TEXTAREA" && event.target.tagName !== "SELECT") {
+      event.preventDefault(); // Prevent page scrolling, but let space work in input fields
+    }
   }
 }
 

--- a/packages/engine/Source/Core/ScreenSpaceEventHandler.js
+++ b/packages/engine/Source/Core/ScreenSpaceEventHandler.js
@@ -32,7 +32,6 @@ function getInputEventKey(type, modifier) {
 }
 
 function getModifier(event, screenSpaceEventHandler) {
-  console.log("getModifier", event, screenSpaceEventHandler._spaceKeyDown);
   if (event.shiftKey) {
     return KeyboardEventModifier.SHIFT;
   } else if (event.ctrlKey) {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Space key handling: when focus is on form controls (input, textarea, select), pressing Space now behaves normally (e.g., inserts a space) instead of blocking default behavior.
  - Preserves previous behavior outside form fields, where Space continues to prevent page scrolling as before.
  - Improves typing and interaction within forms without affecting non-form keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->